### PR TITLE
Use Services global variable

### DIFF
--- a/composeprefsapi/implementation.js
+++ b/composeprefsapi/implementation.js
@@ -1,5 +1,4 @@
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var composePrefsApi = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {

--- a/icapi/implementation.js
+++ b/icapi/implementation.js
@@ -1,5 +1,4 @@
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { EventEmitter } = ChromeUtils.import("resource://gre/modules/EventEmitter.jsm");
 
 var HTB = {};
@@ -366,8 +365,6 @@ var icApi = class extends ExtensionCommon.ExtensionAPI {
       }
     }
     // Clear caches that could prevent upgrades from working properly
-    const { Services } = ChromeUtils.import(
-      "resource://gre/modules/Services.jsm");
     Services.obs.notifyObservers(null, "startupcache-invalidate", null);
   }
   getAPI(context) {

--- a/legacyprefsapi/implementation.js
+++ b/legacyprefsapi/implementation.js
@@ -2,7 +2,6 @@
 /* taken and slightly modified from https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs */
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var legacyPrefsApi = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 91.